### PR TITLE
Automatically copy the resources to the debug dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,6 +754,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "getrandom"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,6 +972,7 @@ dependencies = [
 name = "gremory"
 version = "0.1.0"
 dependencies = [
+ "fs_extra",
  "ggez",
  "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,11 @@
 name = "gremory"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
 
 [dependencies]
 ggez = "0.9.3"
 rand = "0.8.5"
+
+[build-dependencies]
+fs_extra = "1.2"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,16 @@
+use std::path::Path;
+use fs_extra::dir::{self, CopyOptions};
+
+fn main() {
+    let source_path = Path::new("resources");
+    let dest_path = Path::new("target/debug");
+
+    let mut options = CopyOptions::new();
+    options.overwrite = true;
+
+    if source_path.exists() {
+        dir::copy(source_path, dest_path, &options).expect("Failed to copy resources");
+    } else {
+        panic!("Source path does not exist");
+    }
+}


### PR DESCRIPTION
1. Adds a new `build.rs` file which simply copies the `/resources` directory to the `/target/debug` directory.
2. Adds the `fs_extra` build dep which allows us to move directories around.
3. Adds the `build.rs` script to the `Cargo.toml` file so that it will run at build time.